### PR TITLE
[FEAT] 이메일 인증 코드 전송, 이메일 인증 #2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tripcok/tripcokserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tripcok/tripcokserver/domain/member/controller/MemberController.java
@@ -2,21 +2,44 @@ package com.tripcok.tripcokserver.domain.member.controller;
 
 import com.tripcok.tripcokserver.domain.member.dto.MemberRequestDto;
 import com.tripcok.tripcokserver.domain.member.service.MemberService;
+import com.tripcok.tripcokserver.global.service.EmailService;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.UnsupportedEncodingException;
+
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/member")
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
+    private final EmailService emailService;
 
     /* 회원가입 */
     @PostMapping("/register")
     public ResponseEntity<?> createMember(@RequestBody MemberRequestDto.save request) {
         return memberService.createMember(request);
+    }
+
+    /* 회원가입 - 이매일 인증번호 전송 */
+    @GetMapping("/register/{email}")
+    public ResponseEntity<?> sendVerificationEmail(@PathVariable("email") String email) throws MessagingException, UnsupportedEncodingException {
+        log.info(email);
+        return emailService.sendVerificationEmail(email);
+    }
+
+    /* 회원가입 - 이매일 인증번호 인증 */
+    @GetMapping("/register/email/check")
+    public ResponseEntity<?> checkVerificationEmail(
+            @RequestParam("email") String email,
+            @RequestParam("code") String code
+    ) {
+        return emailService.verifyCode(email,code);
     }
 
     /* 로그인 */

--- a/src/main/java/com/tripcok/tripcokserver/global/config/MailConfig.java
+++ b/src/main/java/com/tripcok/tripcokserver/global/config/MailConfig.java
@@ -1,0 +1,50 @@
+package com.tripcok.tripcokserver.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@PropertySource("classpath:application-local.yml")
+@ConfigurationProperties(prefix = "mail")
+@Getter
+@Setter
+@ToString
+public class MailConfig {
+
+    private String username;
+    private String password;
+
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setHost("smtp.naver.com"); // 메인 도메인 서버 주소 => 정확히는 smtp 서버 주소
+        javaMailSender.setUsername(username); // 네이버 아이디
+        javaMailSender.setPassword(password); // 네이버 비밀번호
+        javaMailSender.setPort(465); // 메일 인증서버 포트
+        javaMailSender.setJavaMailProperties(getMailProperties()); // 메일 인증서버 정보 가져오기
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.transport.protocol", "smtp");
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+        properties.setProperty("mail.debug", "true");
+        properties.setProperty("mail.smtp.ssl.trust", "smtp.naver.com");
+        properties.setProperty("mail.smtp.ssl.enable", "true");
+        return properties;
+    }
+}

--- a/src/main/java/com/tripcok/tripcokserver/global/service/EmailService.java
+++ b/src/main/java/com/tripcok/tripcokserver/global/service/EmailService.java
@@ -1,0 +1,79 @@
+package com.tripcok.tripcokserver.global.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EmailService {
+
+    @Value(value = "${mail.username}")
+    private String SENDER_EMAIL;
+
+    private final HttpSession session;
+    private final JavaMailSender mailSender;
+
+    private static final long CODE_EXPIRATION_TIME = 300_000; // 5분
+
+    public ResponseEntity<?> sendVerificationEmail(String email) throws MessagingException, UnsupportedEncodingException {
+
+        MimeMessage message = mailSender.createMimeMessage();
+        String code = generateVerificationCode();
+
+        message.addRecipients(MimeMessage.RecipientType.TO, email);
+
+        try {
+            message.setSubject("TripCok 인증 코드 안내");
+        } catch (MessagingException e) {
+            throw new RuntimeException(e);
+        }
+
+        String body = "<div>"
+                + "<h1> 안녕하세요. Tripcok 입니다</h1>"
+                + "<br>"
+                + "<p>안내 인증 코드에 따라 인증 번호를 입력해주세여.<p>"
+                + "<p>인증 코드 : " + code + "</p>"
+                + "</div>";
+
+        message.setText(body, "utf-8", "html");
+        message.setFrom(new InternetAddress(SENDER_EMAIL, "TripCok"));
+        mailSender.send(message);
+
+        session.setAttribute(email, code);
+        session.setMaxInactiveInterval((int) (CODE_EXPIRATION_TIME / 1000)); // 세션 만료 시간 설정
+
+
+        return ResponseEntity.ok().build();
+    }
+
+    public ResponseEntity<?> verifyCode(String email, String code) {
+        log.info("verify code {}", code);
+        log.info("verify email {}", email);
+        String storedCode = (String) session.getAttribute(email);
+        log.info("verify storedCode {}", storedCode);
+
+        if (storedCode != null && storedCode.equals(code)) {
+            session.removeAttribute(email);
+            return ResponseEntity.status(HttpStatus.OK).body("인증에 성공하였습니다. 기존 코드는 삭제 됩니다.");
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증에 실패하였습니다.");
+    }
+
+    private String generateVerificationCode() {
+        return String.format("%04d", new Random().nextInt(9999));
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,11 @@ spring:
         show_sql: false
         format_sql: false
 
+mail:
+  username: 네이버 이메일
+  password: 네이버 비밀번호
+
+
 save:
   location:
     place: /place-image


### PR DESCRIPTION
## 셋팅

```yml
spring:
  servlet:
    multipart:
      enabled: true
      max-file-size: 10MB
      max-request-size: 10MB
  datasource:
    url: jdbc:mariadb://localhost:3366/tripcok_db
    username: tripcok
    password: tripcok1234
    driver-class-name: org.mariadb.jdbc.Driver

  jpa:
    hibernate:
      ddl-auto: update
    properties:
      hibernate:
        dialect: org.hibernate.dialect.MariaDBDialect
        show_sql: false
        format_sql: false

mail:
  username: 네이버 이메일 <-- 자신의 네이버 이메일을 적어주세요.
  password: 네이버 비밀번호 <--  자신의 네이버 비밀번호를 적어주세요.

save:
  location:
    place: /place-image
```

## 기능

- [x] 이메일 인증 코드 전송
  - [x]이메일 인증 코드 10분간 유효
- [x] 이메일 인증 코드 인증